### PR TITLE
ajs 1.2.1

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -1,3 +1,5 @@
+"use strict";
+
 //     Thanks to mishoo/uglifyjs for most of this!
 
 // [&laquo; Back to Index](index.html)
@@ -654,6 +656,7 @@ var MAP;
 
 (function(){
   MAP = function(a, f, o) {
+    o = o || {};
     var ret = [];
     for (var i = 0; i < a.length; ++i) {
       var val = f.call(o, a[i], i);

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "view",
     "asynchronous"
   ],
-  "version": "1.2.0",
+  "version": "1.2.1",
   "author": "Ionică Bizău <bizauionica@gmail.com> (http://ionicabizau.net)",
   "contributors": [
     "Evan Owen <kainosnoema@gmail.com>"


### PR DESCRIPTION
Default the scope to empty object in the `MAP` function.