### PR TITLE
Fixes missing babel-runtime error with git-stats-html

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,10 +14,12 @@
   "version": "1.2.11",
   "author": "Ionică Bizău <bizauionica@gmail.com> (https://ionicabizau.net)",
   "contributors": [
-    "Evan Owen <kainosnoema@gmail.com>"
+    "Evan Owen <kainosnoema@gmail.com>",
+    "Spencer Gregson <sgregson@users.noreply.github.com>"
   ],
   "main": "./lib/index.js",
   "dependencies": {
+    "babel-runtime": "^6.23.0",
     "cli": ">= 0.3.6 < 0.5.0",
     "connect": ">= 1.3.0 < 1.5.0",
     "idy": "^1.2.3",


### PR DESCRIPTION
Fixes #23 

From the initial issue, dependent project `git-stats-html` threw an error on `/lib/index.js` that was missing the babel-runtime. Research showed comparable issues stemming from a missing dependency. Kicking off this PR in case it's actually this simple.

- I tested `git-stats-html` and this fixes the issue that was being thrown.
- Ran `npm run test` suite, no issues, though I'm uncertain whether there's a test case that should be written for this.